### PR TITLE
Fix: Correct JSON object access in OBD state parsing

### DIFF
--- a/src/obd.cpp
+++ b/src/obd.cpp
@@ -174,13 +174,15 @@ void OBDClass::fromJSON(T *state, JsonDocument &doc) {
         }
     }
 
-    if (!doc["value"]["format"].isNull()) {
-        state->setValueFormat(doc["value"]["format"].as<std::string>().c_str());
-    }
-    if (!doc["value"]["func"].isNull()) {
-        setFormatFuncByName<T>(doc["value"]["func"].as<std::string>().c_str(), state);
-    } else if (!doc["value"]["expr"].isNull()) {
-        state->setValueFormatExpression(doc["value"]["expr"].as<std::string>().c_str());
+    if (!doc["value"].isNull()) {
+        if (!doc["value"]["format"].isNull()) {
+            state->setValueFormat(doc["value"]["format"].as<std::string>().c_str());
+        }
+        if (!doc["value"]["func"].isNull()) {
+            setFormatFuncByName<T>(doc["value"]["func"].as<std::string>().c_str(), state);
+        } else if (!doc["value"]["expr"].isNull()) {
+            state->setValueFormatExpression(doc["value"]["expr"].as<std::string>().c_str());
+        }
     }
 
     // is reset by setPIDSettings
@@ -233,7 +235,7 @@ void OBDClass::readJSON(JsonDocument &doc) {
                 stateObj["diagnostic"].as<bool>()
             );
             Serial.printf("initalized state variable %s\n", state->getName());
-            fromJSON(state, doc);
+            fromJSON(state, stateObj);
             Serial.printf("read into state variable %s\n", state->getName());
             addState(state);
             Serial.printf("added state variable %s to OBD states\n", state->getName());
@@ -249,7 +251,7 @@ void OBDClass::readJSON(JsonDocument &doc) {
                 stateObj["diagnostic"].as<bool>()
             );
             Serial.printf("initalized state variable %s\n", state->getName());
-            fromJSON(state, doc);
+            fromJSON(state, stateObj);
             Serial.printf("read into state variable %s\n", state->getName());
             addState(state);
             Serial.printf("added state variable %s to OBD states\n", state->getName());
@@ -265,7 +267,7 @@ void OBDClass::readJSON(JsonDocument &doc) {
                 stateObj["diagnostic"].as<bool>()
             );
             Serial.printf("initalized state variable %s\n", state->getName());
-            fromJSON(state, doc);
+            fromJSON(state, stateObj);
             Serial.printf("read into state variable %s\n", state->getName());
             addState(state);
             Serial.printf("added state variable %s to OBD states\n", state->getName());


### PR DESCRIPTION
The `OBDClass::fromJSON` method was being called with the entire JSON document (array) instead of the specific JSON object for the individual state being parsed. This caused issues when trying to access nested properties like "pid" or "value", as they would be sought at the root of the array instead of within the state's object, leading to null pointer exceptions or incorrect data initialization.

This commit corrects the call in `OBDClass::readJSON` to pass the individual `stateObj` to `fromJSON`.

Additionally, a null check has been added within `OBDClass::fromJSON` before accessing members of the "value" object to improve robustness against potentially missing optional fields in the JSON configuration. The "pid" object was confirmed to already have such a safeguard.