### PR TITLE
Fix: Improve robustness of OBD state debug printing

### DIFF
--- a/src/OBDState.cpp
+++ b/src/OBDState.cpp
@@ -512,6 +512,8 @@ char *TypedOBDState<T>::formatValue() {
     }
 
     char str[50];
+    memset(str, 0, sizeof(str)); // Initialize buffer
+
     if (strlen(this->valueFormatExpression) != 0) {
         ExprParser parser;
         parser.setVariableResolveFunction([&](const char *varName)-> double {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -363,32 +363,58 @@ bool sendOBDData() {
 
         for (auto& state : states) {
             char tmp_char[50];
+        memset(tmp_char, 0, sizeof(tmp_char)); // Initialize tmp_char
+
             if (state->getLastUpdate() + state->getUpdateInterval() > millis()) {
                 continue;
             }
 
             DEBUG_PORT.printf("Sending state %s...\n", state->getName());
 
-            if (state->valueType() == "int") {
+        if (strcmp(state->valueType(), "int") == 0) {
                 auto* is = reinterpret_cast<OBDStateInt*>(state);
                 char* str = is->formatValue();
-                strcpy(tmp_char, str);
+            if (str) {
+                strncpy(tmp_char, str, sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0'; // Ensure null termination
                 free(str);
-            } else if (state->valueType() == "float") {
+            } else {
+                strncpy(tmp_char, "ErrorFmtInt", sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0';
+            }
+        } else if (strcmp(state->valueType(), "float") == 0) {
                 auto* is = reinterpret_cast<OBDStateFloat*>(state);
                 char* str = is->formatValue();
-                strcpy(tmp_char, str);
+            if (str) {
+                strncpy(tmp_char, str, sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0'; // Ensure null termination
                 free(str);
-            } else if (state->valueType() == "bool") {
+            } else {
+                strncpy(tmp_char, "ErrorFmtFlt", sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0';
+            }
+        } else if (strcmp(state->valueType(), "bool") == 0) {
                 auto* is = reinterpret_cast<OBDStateBool*>(state);
                 char* str = is->formatValue();
-                strcpy(tmp_char, str);
+            if (str) {
+                strncpy(tmp_char, str, sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0'; // Ensure null termination
                 free(str);
+            } else {
+                strncpy(tmp_char, "ErrorFmtBool", sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0';
+            }
+        } else {
+            const char* unknown_type_msg = "UnknownType:";
+            strncpy(tmp_char, unknown_type_msg, sizeof(tmp_char) - 1);
+            tmp_char[sizeof(tmp_char) - 1] = '\0'; // ensure null termination
+            // Optionally append the actual valueType if it's short enough
+            // strncat(tmp_char, state->valueType(), sizeof(tmp_char) - strlen(tmp_char) - 1);
             }
 
-            DEBUG_PORT.printf("State %s: %s\n", state->getName(), std::string(tmp_char));
+        DEBUG_PORT.printf("State %s: %s\n", state->getName(), std::string(tmp_char).c_str());
 
-            // allSendsSucceeded |= mqtt.sendTopicUpdate(state->getName(), std::string(tmp_char));
+        // allSendsSucceeded |= mqtt.sendTopicUpdate(state->getName(), std::string(tmp_char).c_str());
         }
     } else {
         allSendsSucceeded = true;
@@ -437,30 +463,56 @@ bool sendStaticDiagnosticData() {
     if (!states.empty()) {
         for (auto& state : states) {
             char tmp_char[50];
+        memset(tmp_char, 0, sizeof(tmp_char)); // Initialize tmp_char
+
             if (state->getLastUpdate() + state->getUpdateInterval() > millis()) {
                 continue;
             }
 
-            if (state->valueType() == "int") {
+        if (strcmp(state->valueType(), "int") == 0) {
                 auto* is = reinterpret_cast<OBDStateInt*>(state);
                 char* str = is->formatValue();
-                strcpy(tmp_char, str);
+            if (str) {
+                strncpy(tmp_char, str, sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0'; // Ensure null termination
                 free(str);
-            } else if (state->valueType() == "float") {
+            } else {
+                strncpy(tmp_char, "ErrorFmtInt", sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0';
+            }
+        } else if (strcmp(state->valueType(), "float") == 0) {
                 auto* is = reinterpret_cast<OBDStateFloat*>(state);
                 char* str = is->formatValue();
-                strcpy(tmp_char, str);
+            if (str) {
+                strncpy(tmp_char, str, sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0'; // Ensure null termination
                 free(str);
-            } else if (state->valueType() == "bool") {
+            } else {
+                strncpy(tmp_char, "ErrorFmtFlt", sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0';
+            }
+        } else if (strcmp(state->valueType(), "bool") == 0) {
                 auto* is = reinterpret_cast<OBDStateBool*>(state);
                 char* str = is->formatValue();
-                strcpy(tmp_char, str);
+            if (str) {
+                strncpy(tmp_char, str, sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0'; // Ensure null termination
                 free(str);
+            } else {
+                strncpy(tmp_char, "ErrorFmtBool", sizeof(tmp_char) - 1);
+                tmp_char[sizeof(tmp_char) - 1] = '\0';
+            }
+        } else {
+            const char* unknown_type_msg = "UnknownType:";
+            strncpy(tmp_char, unknown_type_msg, sizeof(tmp_char) - 1);
+            tmp_char[sizeof(tmp_char) - 1] = '\0'; // ensure null termination
+            // Optionally append the actual valueType if it's short enough
+            // strncat(tmp_char, state->valueType(), sizeof(tmp_char) - strlen(tmp_char) - 1);
             }
 
-            DEBUG_PORT.printf("State %s: %s\n", state->getName(), std::string(tmp_char));
+        DEBUG_PORT.printf("State %s: %s\n", state->getName(), std::string(tmp_char).c_str());
 
-            // allSendsSucceeded |= mqtt.sendTopicUpdate(state->getName(), std::string(tmp_char));
+        // allSendsSucceeded |= mqtt.sendTopicUpdate(state->getName(), std::string(tmp_char).c_str());
         }
     } else {
         allSendsSucceeded = true;


### PR DESCRIPTION
This change addresses potential garbage output when debug printing OBD state values by:
- Initializing local buffers in main.cpp's sendOBDData and sendStaticDiagnosticData.
- Using strncpy for safer string copying from formatValue's result.
- Handling unknown valueType strings to prevent use of uninitialized data.
- Ensuring formatValue's internal buffer in OBDState.cpp is initialized.
- Using .c_str() for printf with std::string for better type safety.

These changes aim to prevent crashes or garbage output and provide clearer diagnostic messages if issues persist.